### PR TITLE
Lemony's/feat/#10

### DIFF
--- a/PokemonPhoneBook/Controller/PhoneBookViewController.swift
+++ b/PokemonPhoneBook/Controller/PhoneBookViewController.swift
@@ -129,14 +129,6 @@ class PhoneBookViewController: UIViewController {
         if profileImageUrl == nil {
             profileImageUrl = PhoneBookImageUrl
         }
-//        guard let name = nameTextField.text,
-//              let phone = phoneNumTextField.text else {
-//            print("이름이나 전화번호가 비어있음")
-//            return
-//        }
-//        guard let currentImageUrl = PhoneBookImageUrl,
-//              let currentName = PhoneBookName,
-//              let currentPhoneNumber = PhoneBookPhoneNumber else { return }
         
         if isUpdate {
             CoreDataManager.shared.updateData(

--- a/PokemonPhoneBook/Controller/PhoneBookViewController.swift
+++ b/PokemonPhoneBook/Controller/PhoneBookViewController.swift
@@ -25,6 +25,7 @@ class PhoneBookViewController: UIViewController {
         imageView.layer.borderColor = UIColor.gray.cgColor
         imageView.layer.borderWidth = 3
         imageView.layer.cornerRadius = 80
+        imageView.clipsToBounds = true
         return imageView
     }()
     

--- a/PokemonPhoneBook/Model/CoreDataManager.swift
+++ b/PokemonPhoneBook/Model/CoreDataManager.swift
@@ -81,47 +81,21 @@ class CoreDataManager {
         let fetchRequest = PhoneBook.fetchRequest()
         
         // predicate 는 조건을 걸어주는 구문
-        fetchRequest.predicate = NSPredicate(format: "imageUrl == %@", currentImageUrl)
+        // 예외처리: imageUrl 이 "" 면 nil 인 값을 찾게 함.
+        fetchRequest.predicate = NSPredicate(format: "(imageUrl == %@ OR imageUrl == nil) AND name == %@ AND phoneNumber == %@", currentImageUrl, currentName, currentPhoneNumber)
         do {
             let result = try self.container.viewContext.fetch(fetchRequest)
-            
-            for data in result as [NSManagedObject] {
-                data.setValue(updateImageUrl, forKey: PhoneBook.Key.imageUrl)
+
+            if let objectToUpdate = result.first {
+                objectToUpdate.setValue(updateImageUrl, forKey: "imageUrl")
+                objectToUpdate.setValue(updateName, forKey: "name")
+                objectToUpdate.setValue(updatePhoneNumber, forKey: "phoneNumber")
+                
+                try self.container.viewContext.save()
+                print("데이터 수정 성공")
+            } else {
+                print("일치하는 데이터 없음")
             }
-            
-            try self.container.viewContext.save()
-            
-            print("데이터 수정 성공")
-        } catch {
-            print("데이터 수정 실패")
-        }
-        
-        fetchRequest.predicate = NSPredicate(format: "name == %@", currentName)
-        do {
-            let result = try self.container.viewContext.fetch(fetchRequest)
-            
-            for data in result as [NSManagedObject] {
-                data.setValue(updateName, forKey: PhoneBook.Key.name)
-            }
-            
-            try self.container.viewContext.save()
-            
-            print("데이터 수정 성공")
-        } catch {
-            print("데이터 수정 실패")
-        }
-        
-        fetchRequest.predicate = NSPredicate(format: "phoneNumber == %@", currentPhoneNumber)
-        do {
-            let result = try self.container.viewContext.fetch(fetchRequest)
-            
-            for data in result as [NSManagedObject] {
-                data.setValue(updatePhoneNumber, forKey: PhoneBook.Key.phoneNumber)
-            }
-            
-            try self.container.viewContext.save()
-            
-            print("데이터 수정 성공")
         } catch {
             print("데이터 수정 실패")
         }

--- a/PokemonPhoneBook/View/PhoneBookTableViewCell.swift
+++ b/PokemonPhoneBook/View/PhoneBookTableViewCell.swift
@@ -17,6 +17,7 @@ class PhoneBookTableViewCell: UITableViewCell {
         imageView.layer.borderColor = UIColor.gray.cgColor
         imageView.layer.borderWidth = 1
         imageView.layer.cornerRadius = 30
+        imageView.clipsToBounds = true
         return imageView
     }()
     

--- a/PokemonPhoneBook/View/PhoneBookTableViewCell.swift
+++ b/PokemonPhoneBook/View/PhoneBookTableViewCell.swift
@@ -51,6 +51,15 @@ class PhoneBookTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        // 셀을 초기화
+        pokemonImageView.image = nil
+        nameLabel.text = ""
+        phoneNumLabel.text = ""
+    }
+    
     private func setPokemonImageView() {
         contentView.addSubview(pokemonImageView)
         


### PR DESCRIPTION
close #8 

## *⛳️ Work Description*
- Lv.8 및 Challenge 구현 완료
 
## *📸 Screenshot*
![Simulator Screen Recording - iPhone 16 Pro - 2025-04-23 at 20 53 01](https://github.com/user-attachments/assets/51cf19e6-4101-4dfc-a0ed-46c49fda9ab7)

## *📢 To Reviewers*
### Lv8
- [x] UITableViewCell 을 클릭해서 이동해온 연락처 편집 페이지에서, 실제로 기기 디스크 데이터에 Update 가 일어나도록 구현합니다.
- [x] “적용” 버튼을 클릭했을때, 새로운 전화번호 데이터를 추가(Create)하는 것이 아닌, 기존 데이터를 수정(Update) 하도록 합니다.
- [x] 그리고 적용 버튼을 클릭하면 다시 메인화면으로 이동하고, 이때 수정된 내용이 반영되어 노출되어야 합니다.

### Challenge
- [x] 포켓몬 덩치가 클 때, 이미지 원 영역을 벗어나는 경우가 있습니다. 이 때 원 밖을 벗어나지 않도록 구현해볼 수 있을까요? 원래라면 아래 포켓몬은 날개 부분이 살짝 밖으로 삐져나오게 됩니다.
- [x] 연락처를 매우 많이 추가했을 경우(20개 이상), 테이블 뷰 스크롤을 쭉 내리다보면, 이미지가 겹쳐보이거나 텍스트가 제대로 노출되지 않는 문제를 마주칠 수 있습니다.

## *✅ Checklist*
- [x] 주석 및 프린트문 제거 확인.
- [x] 컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.